### PR TITLE
Plug leak in control_get_value

### DIFF
--- a/src/control.c
+++ b/src/control.c
@@ -36,6 +36,7 @@ static Bool control_get_value(Control* obj, int device_index, unsigned char* val
 			False, XA_INTEGER, &type, &format, &size, &bytes, &data) == Success &&
 			type != None) {
 		*value = data[0];
+		free(data);
 		return True;
 	}
 	return False;


### PR DESCRIPTION
Previous it leaked a few bytes every second.  I observed dispad using
400 MB on a machine with 16 days of uptime.
