### PR TITLE
Fix reversed memcpy arguments

### DIFF
--- a/src/listen.c
+++ b/src/listen.c
@@ -89,7 +89,7 @@ Bool listen_init(Listen* obj, Display* display, Bool modifiers,
 	}
 
 	XQueryKeymap(obj->display, (char*)obj->current);
-	memcpy(obj->current, obj->previous,
+	memcpy(obj->previous, obj->current,
 		sizeof(unsigned char)*MTRACKD_KEYMAP_SIZE);
 	return True;
 }


### PR DESCRIPTION
The intent is to initialize the previous state to the current state.
Fixes a Valgrind uninitialized value warning.
