### PR TITLE
Fix reversed arguments to memcpy

### DIFF
--- a/src/listen.c
+++ b/src/listen.c
@@ -58,7 +58,7 @@ static Bool listen_activity(Listen* obj) {
 		}
 	}
 
-	memcpy(obj->current, obj->previous,
+	memcpy(obj->previous, obj->current,
 		sizeof(unsigned char)*MTRACKD_KEYMAP_SIZE);
 	return res;
 }


### PR DESCRIPTION
We intend to copy the current state to the previous, just like
initialization.
