### PR TITLE
Issue 2

### DIFF
--- a/src/listen.c
+++ b/src/listen.c
@@ -46,15 +46,9 @@ static Bool listen_activity(Listen* obj) {
 		if ((obj->current[i] & ~obj->previous[i]) & obj->mask[i]) {
 			res = True;
 			break;
-		}
-	}
-
-	if (res && !obj->modifiers) {
-		for (i = 0; i < MTRACKD_KEYMAP_SIZE; i++) {
-			if (obj->current[i] & ~obj->mask[i]) {
-				res = False;
-				break;
-			}
+		} else if (obj->modifiers && (obj->current[i] & ~obj->mask[i])) {
+			res = True;
+			break;
 		}
 	}
 
@@ -75,17 +69,15 @@ Bool listen_init(Listen* obj, Display* display, Bool modifiers,
 	obj->display = display;
 	memset(obj->mask, 0xff, MTRACKD_KEYMAP_SIZE);
 
-	if (!modifiers) {
-		modmap = XGetModifierMapping(obj->display);
+	modmap = XGetModifierMapping(obj->display);
 
-		for (i = 0; i < 8 * modmap->max_keypermod; i++) {
-			kc = modmap->modifiermap[i];
-			if (kc != 0)
-				clear_bit(obj->mask, kc);
-		}
-
-		XFreeModifiermap(modmap);
+	for (i = 0; i < 8 * modmap->max_keypermod; i++) {
+		kc = modmap->modifiermap[i];
+		if (kc != 0)
+			clear_bit(obj->mask, kc);
 	}
+
+	XFreeModifiermap(modmap);
 
 	XQueryKeymap(obj->display, (char*)obj->current);
 	memcpy(obj->previous, obj->current,


### PR DESCRIPTION
When used in the default mode, we did not disable the trackpad when
the user pressed both modifier and non-modifier keys.  Also when used
in the modifier-sensitive mode, we did not disable the trackpad while
the modifier key was pressed and held.  Closes issue #2.
